### PR TITLE
Add separate-session pipeline variants for comparison

### DIFF
--- a/Sources/DeepThinkKit/Core/Pipeline.swift
+++ b/Sources/DeepThinkKit/Core/Pipeline.swift
@@ -95,7 +95,9 @@ public enum PipelineKind: String, Codable, Sendable, CaseIterable, Identifiable 
     case auto
     case direct
     case sequential
+    case sequentialSeparate
     case critiqueLoop
+    case critiqueLoopSeparate
     case branchMerge
     case selfConsistency
     case verified
@@ -107,7 +109,9 @@ public enum PipelineKind: String, Codable, Sendable, CaseIterable, Identifiable 
         case .auto: "Auto"
         case .direct: "Direct (Single-Pass)"
         case .sequential: "Sequential"
+        case .sequentialSeparate: "Sequential (Separate)"
         case .critiqueLoop: "Critique Loop"
+        case .critiqueLoopSeparate: "Critique Loop (Separate)"
         case .branchMerge: "Branch & Merge"
         case .selfConsistency: "Self-Consistency"
         case .verified: "Verified (CSP)"
@@ -122,8 +126,12 @@ public enum PipelineKind: String, Codable, Sendable, CaseIterable, Identifiable 
             "Query -> Response (no reasoning stages)"
         case .sequential:
             "Think step-by-step → Answer (multi-turn)"
+        case .sequentialSeparate:
+            "Think step-by-step → Answer (separate sessions)"
         case .critiqueLoop:
             "Answer → Review → Final (multi-turn)"
+        case .critiqueLoopSeparate:
+            "Answer → Review → Final (separate sessions)"
         case .branchMerge:
             "Analyze -> {Solve A, B, C} -> Merge -> Finalize"
         case .selfConsistency:

--- a/Sources/DeepThinkKit/Pipeline/CritiqueLoopSeparatePipeline.swift
+++ b/Sources/DeepThinkKit/Pipeline/CritiqueLoopSeparatePipeline.swift
@@ -1,0 +1,174 @@
+import Foundation
+
+// MARK: - Critique Loop Pipeline (Separate Sessions)
+// Answer -> Review -> Final Answer — each step uses a fresh session
+
+public struct CritiqueLoopSeparatePipeline: Pipeline, Sendable {
+    public let name = "CritiqueLoopSeparate"
+    public let description = "Answer → Review → Final (separate sessions per step)"
+    public let configuration: PipelineConfiguration
+
+    public var stages: [any Stage] { [] }
+
+    public init(configuration: PipelineConfiguration = .default) {
+        self.configuration = configuration
+    }
+
+    public func execute(query: String, context: PipelineContext) async throws -> PipelineResult {
+        let startTime = Date.now
+        await context.traceCollector.setPipeline(name: name, executionId: context.executionId)
+        await context.traceCollector.record(event: .pipelineStarted(name: name, query: query))
+
+        let searchStageCount = configuration.webSearchEnabled ? 1 : 0
+        await context.emit(.pipelineStarted(pipelineName: name, stageCount: 3 + searchStageCount))
+
+        var allOutputs: [StageOutput] = []
+        var stageIndex = 0
+
+        do {
+            // Optional: Web Search
+            var webSearchContext = ""
+            if configuration.webSearchEnabled {
+                let wsOutput = try await executeWebSearchIfEnabled(
+                    query: query, context: context, configuration: configuration,
+                    allOutputs: &allOutputs, stageIndex: &stageIndex
+                )
+                if let ws = wsOutput, ws.metadata["searchDecision"] == "searched" {
+                    webSearchContext = "\n\n\(truncate(ws.content, to: configuration.webSearchContextBudget))"
+                }
+            }
+
+            // Build memory context
+            let memory = await context.getRetrievedMemory()
+            var memoryContext = ""
+            if !memory.isEmpty {
+                memoryContext = formatMemoryContext(memory)
+            }
+
+            // --- Step 1: Solve (fresh session) ---
+            await context.emit(.stageStarted(stageName: "Solve", stageKind: .solve, index: stageIndex))
+            await context.traceCollector.record(event: .stageStarted(stage: "Solve", kind: .solve, input: query))
+
+            let solveSystemPrompt = localizedSystemPrompt(
+                "You are an assistant that answers carefully and reviews your own work.",
+                language: context.language
+            )
+
+            let solvePrompt = "Answer the following question.\n\nQuestion: \(query)\(memoryContext)\(webSearchContext)"
+
+            let solveRaw = try await streamingGenerate(
+                stageName: "Solve",
+                systemPrompt: solveSystemPrompt,
+                userPrompt: solvePrompt,
+                context: context
+            )
+
+            let solveOutput = parseOutput(raw: solveRaw, kind: .solve)
+            allOutputs.append(solveOutput)
+            await context.setOutput(solveOutput, for: "Solve")
+            await context.traceCollector.record(event: .stageCompleted(stage: "Solve", output: solveOutput))
+            await context.emit(.stageCompleted(stageName: "Solve", stageKind: .solve, output: solveOutput, index: stageIndex))
+            stageIndex += 1
+
+            // --- Step 2: Critique (fresh session, previous answer passed in prompt) ---
+            await context.emit(.stageStarted(stageName: "Critique", stageKind: .critique, index: stageIndex))
+            await context.traceCollector.record(event: .stageStarted(stage: "Critique", kind: .critique, input: ""))
+
+            let critiqueSystemPrompt = localizedSystemPrompt(
+                "You are an expert reviewer who carefully evaluates answers for correctness and completeness.",
+                language: context.language
+            )
+
+            let previousAnswer = summarizeForNextStage(solveOutput)
+            let critiquePrompt = """
+                Review the following answer to the given question.
+                - Are there any factual errors?
+                - Any logical gaps or oversights?
+                - Could the explanation be improved?
+                Point out specific issues if any. If the answer is correct, say "No issues found."
+
+                [Question]
+                \(query)
+
+                [Answer to Review]
+                \(previousAnswer)
+                """
+
+            let critiqueRaw = try await streamingGenerate(
+                stageName: "Critique",
+                systemPrompt: critiqueSystemPrompt,
+                userPrompt: critiquePrompt,
+                context: context
+            )
+
+            let critiqueOutput = parseOutput(raw: critiqueRaw, kind: .critique)
+            allOutputs.append(critiqueOutput)
+            await context.setOutput(critiqueOutput, for: "Critique")
+            await context.traceCollector.record(event: .stageCompleted(stage: "Critique", output: critiqueOutput))
+            await context.emit(.stageCompleted(stageName: "Critique", stageKind: .critique, output: critiqueOutput, index: stageIndex))
+            stageIndex += 1
+
+            // --- Step 3: Final Answer (fresh session, both previous outputs passed in prompt) ---
+            await context.emit(.stageStarted(stageName: "Finalize", stageKind: .finalize, index: stageIndex))
+            await context.traceCollector.record(event: .stageStarted(stage: "Finalize", kind: .finalize, input: ""))
+
+            let finalSystemPrompt = localizedSystemPrompt(
+                "You are an assistant that writes clear, accurate final answers incorporating review feedback.",
+                language: context.language
+            )
+
+            let previousCritique = summarizeForNextStage(critiqueOutput)
+            let finalPrompt = """
+                Based on the original answer and the review feedback, write your final answer.
+                Fix any issues identified in the review, and keep the parts that were correct.
+
+                [Question]
+                \(query)
+
+                [Original Answer]
+                \(previousAnswer)
+
+                [Review Feedback]
+                \(previousCritique)
+                """
+
+            let finalRaw = try await streamingGenerate(
+                stageName: "Finalize",
+                systemPrompt: finalSystemPrompt,
+                userPrompt: finalPrompt,
+                context: context
+            )
+
+            let finalOutput = parseOutput(raw: finalRaw, kind: .finalize)
+            allOutputs.append(finalOutput)
+            await context.setOutput(finalOutput, for: "Finalize")
+            await context.traceCollector.record(event: .stageCompleted(stage: "Finalize", output: finalOutput))
+            await context.emit(.stageCompleted(stageName: "Finalize", stageKind: .finalize, output: finalOutput, index: stageIndex))
+
+        } catch {
+            await context.emit(.pipelineFailed(error: "\(error)"))
+            await context.finishEventStream()
+            throw error
+        }
+
+        let endTime = Date.now
+        let trace = await context.traceCollector.allRecords()
+        await context.traceCollector.record(
+            event: .pipelineCompleted(name: name, duration: endTime.timeIntervalSince(startTime))
+        )
+
+        let result = PipelineResult(
+            pipelineName: name,
+            query: query,
+            finalOutput: allOutputs.last ?? StageOutput(stageKind: .finalize, content: ""),
+            stageOutputs: allOutputs,
+            trace: trace,
+            startTime: startTime,
+            endTime: endTime
+        )
+
+        await context.emit(.pipelineCompleted(result: result))
+        await context.finishEventStream()
+        return result
+    }
+}

--- a/Sources/DeepThinkKit/Pipeline/PipelineFactory.swift
+++ b/Sources/DeepThinkKit/Pipeline/PipelineFactory.swift
@@ -14,8 +14,12 @@ public enum PipelineFactory {
             DirectPipeline(configuration: configuration)
         case .sequential:
             SequentialPipeline(configuration: configuration)
+        case .sequentialSeparate:
+            SequentialSeparatePipeline(configuration: configuration)
         case .critiqueLoop:
             CritiqueLoopPipeline(configuration: configuration)
+        case .critiqueLoopSeparate:
+            CritiqueLoopSeparatePipeline(configuration: configuration)
         case .branchMerge:
             BranchMergePipeline(configuration: configuration)
         case .selfConsistency:

--- a/Sources/DeepThinkKit/Pipeline/SequentialSeparatePipeline.swift
+++ b/Sources/DeepThinkKit/Pipeline/SequentialSeparatePipeline.swift
@@ -1,0 +1,141 @@
+import Foundation
+
+// MARK: - Sequential Pipeline (Separate Sessions)
+// Think (step-by-step) -> Answer — each step uses a fresh session
+
+public struct SequentialSeparatePipeline: Pipeline, Sendable {
+    public let name = "SequentialSeparate"
+    public let description = "Think step-by-step → Answer (separate sessions per step)"
+    public let configuration: PipelineConfiguration
+
+    public var stages: [any Stage] { [] }
+
+    public init(configuration: PipelineConfiguration = .default) {
+        self.configuration = configuration
+    }
+
+    public func execute(query: String, context: PipelineContext) async throws -> PipelineResult {
+        let startTime = Date.now
+        await context.traceCollector.setPipeline(name: name, executionId: context.executionId)
+        await context.traceCollector.record(event: .pipelineStarted(name: name, query: query))
+
+        let searchStageCount = configuration.webSearchEnabled ? 1 : 0
+        await context.emit(.pipelineStarted(pipelineName: name, stageCount: 2 + searchStageCount))
+
+        var allOutputs: [StageOutput] = []
+        var stageIndex = 0
+
+        do {
+            // Optional: Web Search
+            var webSearchContext = ""
+            if configuration.webSearchEnabled {
+                let wsOutput = try await executeWebSearchIfEnabled(
+                    query: query, context: context, configuration: configuration,
+                    allOutputs: &allOutputs, stageIndex: &stageIndex
+                )
+                if let ws = wsOutput, ws.metadata["searchDecision"] == "searched" {
+                    webSearchContext = "\n\n\(truncate(ws.content, to: configuration.webSearchContextBudget))"
+                }
+            }
+
+            // Build memory context
+            let memory = await context.getRetrievedMemory()
+            var memoryContext = ""
+            if !memory.isEmpty {
+                memoryContext = formatMemoryContext(memory)
+            }
+
+            // --- Step 1: Think (fresh session) ---
+            await context.emit(.stageStarted(stageName: "Think", stageKind: .think, index: stageIndex))
+            await context.traceCollector.record(event: .stageStarted(stage: "Think", kind: .think, input: query))
+
+            let thinkSystemPrompt = localizedSystemPrompt(
+                "You are an assistant that thinks carefully before answering.",
+                language: context.language
+            )
+
+            let thinkPrompt = """
+                Think through this question step by step:
+                1. Clarify what is being asked
+                2. Identify key facts and constraints
+                3. Consider your approach
+                4. Check for things easy to overlook
+                Write your thinking process. Do not write the final answer yet.
+
+                Question: \(query)\(memoryContext)\(webSearchContext)
+                """
+
+            let thinkRaw = try await streamingGenerate(
+                stageName: "Think",
+                systemPrompt: thinkSystemPrompt,
+                userPrompt: thinkPrompt,
+                context: context
+            )
+
+            let thinkOutput = parseOutput(raw: thinkRaw, kind: .think)
+            allOutputs.append(thinkOutput)
+            await context.setOutput(thinkOutput, for: "Think")
+            await context.traceCollector.record(event: .stageCompleted(stage: "Think", output: thinkOutput))
+            await context.emit(.stageCompleted(stageName: "Think", stageKind: .think, output: thinkOutput, index: stageIndex))
+            stageIndex += 1
+
+            // --- Step 2: Answer (fresh session, previous thinking passed in prompt) ---
+            await context.emit(.stageStarted(stageName: "Finalize", stageKind: .finalize, index: stageIndex))
+            await context.traceCollector.record(event: .stageStarted(stage: "Finalize", kind: .finalize, input: ""))
+
+            let answerSystemPrompt = localizedSystemPrompt(
+                "You are an assistant that writes clear, accurate answers based on provided analysis.",
+                language: context.language
+            )
+
+            let previousThinking = summarizeForNextStage(thinkOutput)
+            let answerPrompt = """
+                Based on the following thinking process, write your final answer.
+
+                [Question]
+                \(query)
+
+                [Thinking Process]
+                \(previousThinking)
+                """
+
+            let answerRaw = try await streamingGenerate(
+                stageName: "Finalize",
+                systemPrompt: answerSystemPrompt,
+                userPrompt: answerPrompt,
+                context: context
+            )
+
+            let answerOutput = parseOutput(raw: answerRaw, kind: .finalize)
+            allOutputs.append(answerOutput)
+            await context.setOutput(answerOutput, for: "Finalize")
+            await context.traceCollector.record(event: .stageCompleted(stage: "Finalize", output: answerOutput))
+            await context.emit(.stageCompleted(stageName: "Finalize", stageKind: .finalize, output: answerOutput, index: stageIndex))
+
+        } catch {
+            await context.emit(.pipelineFailed(error: "\(error)"))
+            await context.finishEventStream()
+            throw error
+        }
+
+        let endTime = Date.now
+        let trace = await context.traceCollector.allRecords()
+        await context.traceCollector.record(
+            event: .pipelineCompleted(name: name, duration: endTime.timeIntervalSince(startTime))
+        )
+
+        let result = PipelineResult(
+            pipelineName: name,
+            query: query,
+            finalOutput: allOutputs.last ?? StageOutput(stageKind: .finalize, content: ""),
+            stageOutputs: allOutputs,
+            trace: trace,
+            startTime: startTime,
+            endTime: endTime
+        )
+
+        await context.emit(.pipelineCompleted(result: result))
+        await context.finishEventStream()
+        return result
+    }
+}


### PR DESCRIPTION
## Summary
- Add `SequentialSeparatePipeline`: Think → Answer with a fresh `LanguageModelSession` per step (vs multi-turn)
- Add `CritiqueLoopSeparatePipeline`: Solve → Critique → Finalize with a fresh session per step (vs multi-turn)
- Register new `PipelineKind` cases (`.sequentialSeparate`, `.critiqueLoopSeparate`) so they appear in the UI pipeline picker and can be used in ComparisonView

## Motivation
The existing Sequential/CritiqueLoop pipelines run all thinking steps within a single multi-turn session. This PR adds variants that create a separate session for each step, explicitly passing previous outputs in the prompt. This enables side-by-side comparison of:
- **Quality**: Does explicit context passing lose or gain anything vs implicit session history?
- **Performance**: Session overhead vs prompt size trade-off
- **Step independence**: Separate sessions allow per-step system prompts (e.g. "expert reviewer" for Critique)

## Test plan
- [ ] Build succeeds (`swift build`)
- [ ] New pipelines appear in the UI pipeline picker menu
- [ ] Run a query with Sequential vs Sequential (Separate) and compare outputs
- [ ] Run a query with Critique Loop vs Critique Loop (Separate) and compare outputs
- [ ] Use ComparisonView to run both variants side-by-side on the same query

🤖 Generated with [Claude Code](https://claude.com/claude-code)